### PR TITLE
String barbed wire across both ends of the body

### DIFF
--- a/site/src/assets/scss/partials/_general.scss
+++ b/site/src/assets/scss/partials/_general.scss
@@ -162,6 +162,47 @@ figure {
   @include breakpoint(min, large) {
     padding: 4rem;
   }
+
+  /*
+    A length of barbed wire across each end of the body, on every page rather
+    than only under the notice on the home page. Out of the flow, so neither
+    costs any height: they lie over the first and last 12px of the body.
+
+    Positioned, so they paint over the content, which is what puts the top one
+    in front of the header's corner ornaments and the bottom one in front of
+    the footer band. `left` and `right` at 0 is the body's own width, so there
+    is no `adaptive` here as there was when this hung off `.site-top`, which is
+    full width.
+
+    The drawing is 142x12 and is cut to tile, so it repeats across rather than
+    stretching, and the box is the drawing's own height. Its gaps are
+    transparent, so what shows between the barbs is whatever the wire crosses.
+
+    The dark of the two; `wire.svg` is the same drawing in alabaster, for a
+    dark background.
+  */
+  &::before,
+  &::after {
+    content: "";
+    position: absolute;
+    left: 0;
+    right: 0;
+    height: 12px;
+    background-image: url("/images/general/wire-black.svg");
+    background-repeat: repeat-x;
+    /*
+      Above the header's two corner ornaments, which are painted by a
+      positioned box that comes later and cut 200px off each end of the top
+      wire without it.
+    */
+    z-index: 1;
+  }
+  &::before {
+    top: 0;
+  }
+  &::after {
+    bottom: 0;
+  }
 }
 
 .padding--global {

--- a/site/src/templates/DocsTemplate/index.jsx
+++ b/site/src/templates/DocsTemplate/index.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 
+import Announcement from "components/Announcement";
 import Header from "components/Header";
 import SiteFooter from "components/SiteFooter";
 import Sidebar from "docs/Sidebar";
@@ -19,13 +20,17 @@ import "./docs-template.scss";
   change to either one being made carefully around the other.
 
   The header is reused unchanged, which is the point: the documentation is part
-  of the site now rather than a second site that looks like it.
+  of the site now rather than a second site that looks like it. So is the
+  notice above it: it is a site-wide announcement, and a reader who arrives on
+  a documentation page is exactly the one who needs to be told the API has
+  changed.
 */
 function DocsTemplate({ children }) {
   const [open, setOpen] = useState(false);
 
   return (
     <div className="main-container">
+      <Announcement />
       <div className="main-wrapper">
         <Header />
 


### PR DESCRIPTION
`wire-black.svg` has been sitting unused in public/images/general since last year. It is a 142x12 drawing cut to tile, so it repeats across rather than stretching.

Both lengths hang off `.main-wrapper` rather than off the notice, which is what puts them on the documentation pages too, and both are out of the flow so neither costs any height: they lie over the first and last 12px of the body.

They need a `z-index`. The header's two corner ornaments are painted by a positioned box that comes later in the document, and without it they were in front, cutting 200px off each end of the top wire.

The notice moves with them. It was rendered by the home page alone, and a reader who arrives straight on a documentation page is exactly the one who needs to be told the API has changed, so `DocsTemplate` renders it now as well.