### PR TITLE
Keep the primary button's label on hover

### DIFF
--- a/site/src/assets/scss/partials/_buttons.scss
+++ b/site/src/assets/scss/partials/_buttons.scss
@@ -44,6 +44,19 @@ $button-sizes: (
       &:hover {
         @if $name == "primary" {
           background-color: $accent-color;
+          /*
+            Said out loud, because these buttons are links. `a:hover` in
+            _general.scss paints an anchor `$accent-color`, and at (0,1,1) it
+            outranks the `color` on `.button` at (0,1,0) -- so the filled
+            primary button, which is the Download button on the home page, was
+            drawing `$accent-color` text on an `$accent-color` ground and
+            losing its label to the hover.
+
+            The other variants were already safe by accident: `secondary` pins
+            its colour at (0,2,0), and `accent` and the outlined primary both
+            set one in their own hover block.
+          */
+          color: $secondary-color;
           &.button--outlined {
             border-color: $accent-color;
             color: $accent-color;


### PR DESCRIPTION
The Download button on the home page went blank under the pointer: an empty green block with no text in it.

It is an `<a>`, and `a:hover` in _general.scss paints an anchor `$accent-color`. At (0,1,1) that outranks the `color` on `.button` at (0,1,0), and the filled primary's hover block sets a background and no colour, so the label was being painted `$accent-color` on an `$accent-color` ground.

Saying the colour out loud in that block is the whole fix. The other variants were already safe: `secondary` pins its colour at (0,2,0), and `accent` and the outlined primary each set one in their own hover block.

Measured on hover after the change: ground #668f80, label #fafaf8.