### PR TITLE
Share the home page with twitter_summary_large_02

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -17,10 +17,12 @@
     <meta property="og:type" content="product" />
     <meta property="og:title" content="Gerillass: The First AI-ready Sass Library" />
     <meta property="og:description" content="An open-source Sass library of mixins and functions, with a machine-readable manifest the test suite verifies, so AI coding agents can use it as well as you can." />
-    <meta property="og:image" content="https://gerillass.com/images/share/twitter_summary_large_03.jpg" />
+    <meta property="og:image" content="https://gerillass.com/images/share/twitter_summary_large_02.jpg" />
     <meta property="og:image:alt" content="Gerillass, an open-source Sass library that coding agents can read." />
     <meta property="og:image:width" content="1920">
-    <meta property="og:image:height" content="1000">
+    <!-- 1004, not 1000: this drawing is four pixels taller than the one it
+         replaced. Measured, not assumed. -->
+    <meta property="og:image:height" content="1004">
     <meta property="og:image:type" content="image/jpg">
     <meta property="og:site_name" content="Gerillass">
     <meta property="product:category" content="Web Development">


### PR DESCRIPTION
The height goes with it. The two drawings are not the same size: `_02` measures 1920x1004 against `_03`'s 1920x1000, and `og:image:height` is what a preview sizes the frame from before the file arrives.

Twitter has no image of its own here, only `summary_large_image` and no `twitter:image`, so it falls back to this one.