### PR TITLE
Pick the stargazer row in the browser, not at build time

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -4,8 +4,24 @@
     {
       "name": "site",
       "runtimeExecutable": "npm",
-      "runtimeArgs": ["run", "dev", "--prefix", "site"],
+      "runtimeArgs": [
+        "run",
+        "dev",
+        "--prefix",
+        "site"
+      ],
       "port": 5173
+    },
+    {
+      "name": "site-preview",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": [
+        "run",
+        "preview",
+        "--prefix",
+        "site"
+      ],
+      "port": 4173
     }
   ]
 }

--- a/site/src/components/Supporters/index.jsx
+++ b/site/src/components/Supporters/index.jsx
@@ -51,7 +51,21 @@ function writeCachedCount(stargazers) {
   }
 }
 
-/* A different handful on every page load. */
+/*
+  A different handful on every page load, and it has to be picked after the
+  page is in the browser rather than while it is being rendered.
+
+  The site is generated statically: every route is rendered to a real HTML file
+  at build time, so anything chosen during that render is chosen once, for
+  everyone, and written into the file. React then hydrates that markup, and
+  hydration reuses the attributes the server wrote -- it repairs mismatched
+  text, not a different `src` on an <img> -- so a second pick made while
+  rendering would be discarded without a word.
+
+  This worked when it was written: the site was assembled in the browser on
+  every visit, and the pick ran once per visit because the render did.
+  Prerendering arrived a day later and moved that render to build time.
+*/
 function pickRandom(people, count) {
   const pool = people.slice();
   const picked = [];
@@ -67,10 +81,13 @@ class Supporters extends Component {
     this.state = {
       stargazers: SNAPSHOT_STARGAZERS,
       isDialogOpen: false,
+      /*
+        The first render has to be identical on the server and in the browser,
+        or hydration is a mismatch. So it is the head of the list, in order,
+        and the random set replaces it on mount.
+      */
+      rowPeople: PEOPLE_WITH_AVATARS.slice(0, AVATARS_IN_ROW),
     };
-    /* Picked once so re-renders (the star count landing, the dialog opening)
-       keep the same faces; a refresh brings a new set. */
-    this.rowPeople = pickRandom(PEOPLE_WITH_AVATARS, AVATARS_IN_ROW);
     this.closeButton = React.createRef();
     this.openDialog = this.openDialog.bind(this);
     this.closeDialog = this.closeDialog.bind(this);
@@ -81,6 +98,18 @@ class Supporters extends Component {
   componentDidMount() {
     this.isRendered = true;
     document.addEventListener("keydown", this.handleKeyDown);
+
+    /*
+      Before the cache check, which returns early. Behind it, a visitor with a
+      stored star count would keep the row the build wrote and the bug would
+      survive for exactly the people who had been here before.
+
+      Picked once here rather than in render, so the later re-renders -- the
+      star count landing, the dialog opening -- keep the same faces.
+    */
+    this.setState({
+      rowPeople: pickRandom(PEOPLE_WITH_AVATARS, AVATARS_IN_ROW),
+    });
 
     const cached = readCachedCount();
     if (cached) {
@@ -238,14 +267,13 @@ class Supporters extends Component {
   }
 
   render() {
-    const { stargazers, isDialogOpen } = this.state;
-    const visible = this.rowPeople;
+    const { stargazers, isDialogOpen, rowPeople } = this.state;
 
     return (
       <div className="supporters">
         <div className="supporters__people">
           <ul className="supporters__avatars">
-            {visible.map((person) => (
+            {rowPeople.map((person) => (
               <li key={person.login}>
                 {this.renderAvatar(
                   person,


### PR DESCRIPTION
The eight faces under the hero were meant to be a different handful on every visit. They have been the same eight for everyone since the site started prerendering, a day after the row was written.

The pick ran in the constructor, which is to say during render, and render now happens once on this machine: `scripts/prerender.mjs` writes each route to a real HTML file and the eight it chose are in the file. The browser does pick again while hydrating, and that second pick is discarded without a word, because hydration reuses the attributes the server wrote. It repairs mismatched text, not a different `src` on an `<img>`.

So the first render is now the head of the list, in order, which is the same on both sides and hydrates clean, and the random set replaces it on mount. It goes above the star-count cache check in `componentDidMount`, which returns early: behind it, the row would have stayed the build's for anyone who had been to the site before.

Checked against the built site rather than the dev server, since the difference between the two is the whole bug: `dist/index.html` now carries the ordered eight, five loads of the build gave five different sets and none of them the baked one, and the console stayed empty.

`.claude/launch.json` gains the preview server that made that checkable.