### PR TITLE
Keep site, wiki and todos out of the release zip, and check it

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -85,6 +85,20 @@ Expect 98 files / ~40 kB as of v2.1.0: everything under `scss/`, the generated
 `package.json`. If `test/`, `meta/`, `tools/`, `yarn.lock` or
 `node_modules` appear, `.npmignore` is broken — stop and fix it.
 
+The source zip and tarball GitHub attaches to the release are a different
+package. They are built with `git archive` from the tag, and `.npmignore` does
+not reach them; `export-ignore` in `.gitattributes` does. They are meant to hold
+the library's buildable source, not only what npm ships, so check them against
+their own list:
+
+```bash
+node tools/check-archive.js
+```
+
+It must pass before tagging. An unexpected entry means something was committed
+that `.gitattributes` does not keep out, which is how `site/` was headed for the
+first release after 2.1.0 without anyone deciding it.
+
 ## 3b. Write the wiki page for the other repositories
 
 A release is not finished when npm has it. `gerillass.com` and

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+# Kept out of the "Source code" zip and tarball GitHub attaches to every
+# release. Those are built with `git archive`, which never reads .npmignore;
+# npm is handled there. tools/check-archive.js fails if anything else turns up.
+
+# Not the library: another product, and notes nobody installing it needs.
+site export-ignore
+netlify.toml export-ignore
+wiki export-ignore
+todos export-ignore

--- a/.npmignore
+++ b/.npmignore
@@ -13,3 +13,4 @@ tools
 llms.txt
 site
 netlify.toml
+todos

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,7 @@ npm test                          # Jest: sass-true specs, the smoke test, and t
 npx jest -t "mapDeepGet()"      # single test, filtered by the describe/it name
 npm run manifest                  # regenerate gerillass.json and SKILL.md (see below)
 node tools/audit.js               # adversarial sweep: bad arguments at every mixin
+node tools/check-archive.js       # what a GitHub release's source zip would contain
 npm pack --dry-run                # inspect exactly what would be published
 yarn audit                        # must stay at zero across all severities
 ```
@@ -340,7 +341,8 @@ Two things are easy to miss and are called out in every file:
   `tools/build-llms-txt.js`. When a page is published, remove the name there
   and re-run `npm run manifest`.
 
-`wiki/` is excluded from the package by the `*.md` rule in `.npmignore`.
+`wiki/` is excluded from the package by the `*.md` rule in `.npmignore`, and
+from the source zip of a GitHub release by `export-ignore` in `.gitattributes`.
 
 ## Releasing
 
@@ -362,8 +364,19 @@ the short list of things already decided and waiting, and `wiki/` is handover
 for the other repositories. A file in `todos/` is neither decided nor addressed
 to anyone else; it is the reasoning a decision would be made from.
 
-It does not ship. The `*.md` rule in `.npmignore` covers it, as it does
-`wiki/`, and `npm pack --dry-run` lists nothing from it.
+It does not ship, and two separate rules see to that, because npm and GitHub
+build their packages differently:
+
+- **npm:** `todos` is listed in `.npmignore`. The `*.md` rule already covered
+  the Markdown in it, but only by accident; a file of any other type would have
+  been published.
+- **GitHub releases:** the "Source code" zip and tarball attached to a release
+  come from `git archive`, which never reads `.npmignore`. `.gitattributes`
+  marks `todos` as `export-ignore`, along with `site`, `netlify.toml` and
+  `wiki`, none of which is the library either.
+
+Check the first with `npm pack --dry-run` and the second with
+`node tools/check-archive.js`.
 
 Every file there is dated to when it was researched, and **its figures age**.
 Download counts, survey percentages and the state of a standard are exactly the
@@ -395,6 +408,36 @@ What it suggests doing, in its own order:
 And what it argues against: investing further in `llms.txt`, whose measured
 effect is contested; and putting the manifest behind a protocol that only
 serves the file, which Modernisation already declines.
+
+### What `source-comments.md` proposes
+
+Measured 13 September 2026, after the first trial project an agent built with
+the library. The agent read the source rather than the documentation site and
+quoted its comments, and every member it praised was commented while every
+member it tripped on had none. The file proposes comments that say what the
+code cannot (why, the trap, what was measured), never a restatement of the
+signature, and in a set order: the members from that trial first, starting
+with the ones it tripped on.
+
+One part is a defect rather than a proposal and is recorded there with its
+evidence: the two `/* */` comments in `_reset-css.scss` are emitted into the
+user's compiled CSS. The library should use `//` throughout.
+
+### What `agent-trials.md` records
+
+Projects a coding agent built from scratch with the published package, each
+followed by the agent's feedback and by a check here of every claim in it. The
+projects are throwaway; only what they show about the library is kept. Two
+trials so far, on two different models, and the findings both reached
+independently are the ones to trust most.
+
+The file sorts the findings by what they would take: fixes that break nothing
+(`isColor` refusing `var()` and `currentColor`, `position` warning on `null`,
+`breakpoint` silent with three arguments, `counter` failing inside a container
+query), behaviour changes that need a major version or an opt-in, and gaps in
+documentation and the manifest. It also records which of the agents' claims
+turned out wrong, and the two prompt rules that made trial feedback quick to
+check: versions from `npm ls`, and a compiled snippet for every problem.
 
 ## Pending work
 

--- a/todos/agent-trials.md
+++ b/todos/agent-trials.md
@@ -1,0 +1,257 @@
+# Agent trials
+
+Projects built from scratch by a coding agent with Gerillass installed from npm,
+followed by the agent's own feedback, then every claim in that feedback checked
+here by compiling it. The projects themselves do not matter and are not to be
+fixed. What matters is what they reveal about the library.
+
+The point of running more than one: a single model repeats its own blind spots
+in every project, so a finding two different models reach independently is
+worth more than anything either finds alone.
+
+---
+
+## The trials
+
+| | Trial 1 | Trial 2 |
+|---|---|---|
+| Date | 13 September 2026 | 13 September 2026 |
+| Model | Claude Opus 5 | Claude Fable 5.1 |
+| Project | UI/UX designer portfolio, two pages | "Kıyı 2026", conference site: home, programme, speaker pages, print stylesheet |
+| Folder | `~/Desktop/gerillass-deneme` | `~/Desktop/kiyi-2026` |
+| Gerillass | 2.1.0 | 2.1.0 |
+| Dart Sass | 1.104.1 (the agent reported 1.91.0) | 1.104.1 |
+| Build | Sass CLI | Vite 8.3.0 |
+| Load route | `@use "gerillass/scss/gerillass"` with `--load-path=node_modules` | `@use "gerillass" as gls`, resolved by Vite through `exports`, no `loadPaths` |
+| Way into the library | read the source and quoted its comments | said the manifest and `SKILL.md` were enough |
+
+The installed `scss/` was byte-identical to `main` in both, so nothing below has
+been fixed yet.
+
+### What changed between the two prompts
+
+Trial 1's only factual error was the Sass version, read from the `^1.91.0`
+range in `package.json` rather than from what was installed. Trial 2's prompt
+asked for two things and both worked:
+
+1. Versions taken from `npm ls gerillass sass`, not from `package.json`.
+2. Every problem reported with the smallest SCSS that reproduces it, compiled
+   before it was written down.
+
+With a snippet per claim, checking a trial took minutes. Keep both in every
+future prompt. Trial 2's prompt deliberately named none of the known defects,
+so that finding one again means something.
+
+### Verification is still required
+
+Trial 2 still made two wrong claims (below). An agent's report is a list of
+leads, not a list of facts.
+
+---
+
+## Findings, by what to do about them
+
+Every item was reproduced here with the trial's own versions unless marked
+otherwise. **Both** means both trials hit it independently.
+
+### Non-breaking fixes
+
+**`isColor` rejects valid CSS colours.** Both. `triangle(right, var(--track), 8px 12px)`
+and `triangle(right, currentColor, 8px 12px)` raise "is not a color value".
+`color-mix(in srgb, red 50%, blue)` does too; `transparent` and `oklch()` pass.
+The parenthesis rule in `isGutter` covers `var()` and `color-mix()` but not
+`currentColor`, which is a keyword and needs recognising on its own. Both
+agents worked around it the same way: a fake colour, then `border-color`
+overridden with the custom property.
+
+**`position` warns on `null` with an empty message.** Both.
+`position(absolute, 0 null null 0)` produces the right CSS and two warnings
+reading "`` does not look like a length". Skipping an edge with `null` is
+documented on the `position` documentation page, and that page's own example,
+`position(absolute, null 16px 16px 16px)`, prints the same warning. The
+four-argument `border-radius` already skips nulls through
+`fillNulls(..., true)`, so the pattern exists in the library.
+
+**`breakpoint` with three arguments emits nothing and raises nothing.** Found
+while checking trial 1. `breakpoint(between, medium, large)` produces no CSS
+and no error; the working forms are `between, medium large` and
+`medium, large`. Neither trial hit it in its own code. It is the silent
+failure `CLAUDE.md` warns about.
+
+**`reset-css` puts two block comments in the user's CSS.** Both noticed. The
+Meyer licence and the display-role note are `/* */` inside the mixin, so they
+appear in expanded output: trial 1's `main.css`, lines 67 and 92. Compressed
+Sass output and Vite's build drop them, so trial 2's claim that they survive
+compression was wrong. See `source-comments.md`: the library should use `//`.
+
+**`counter` breaks inside a container query.** Trial 2, checked in a browser.
+`container-type: inline-size` scopes counters to the container's subtree, and
+the mixin increments on `.counter-item::before`, which is inside it, so every
+card starts its own counter.
+
+| Variant, in the preview pane's Chromium | Numbers |
+|---|---|
+| no container | 01 02 03 |
+| container on the item, increment on `::before` (the mixin today) | 01 01 01 |
+| container on the list | 01 01 01 |
+| reset on the container element itself (trial 2's first suggestion) | 01 01 01 |
+| **increment on the item itself, `content` still on `::before`** | **01 02 03** |
+
+Moving `counter-increment` from `.counter-item::before` to `.counter-item`
+fixes it and numbered a plain list the same way. Before shipping it: add a
+`meta/` example, and check Firefox and Safari, which were not tested. The
+test page, to rebuild the table:
+
+```html
+<style>
+  .day { counter-reset: c; }
+  .item::before { content: counter(c, decimal-leading-zero) " "; counter-increment: c; }
+  .ctr { container-type: inline-size; }
+  .selfinc { counter-increment: c; }
+  .selfinc::before { content: counter(c, decimal-leading-zero) " "; }
+</style>
+<section class="day"><ol><li class="item ctr">a</li><li class="item ctr">b</li></ol></section>
+<section class="day"><ol><li class="selfinc ctr">a</li><li class="selfinc ctr">b</li></ol></section>
+```
+
+Serve it over HTTP. A page placed in `site/public/` fails the site build on
+purpose, because `plugins/csp.js` rejects any HTML whose inline scripts differ
+from `index.html`, and it also lands in the sitemap; delete it and rebuild.
+
+**`counter` hard-codes its names.** Both. `.counter-start`, `.counter-continue`,
+`.counter-item` and the counter `glsCounter` are fixed, which put library
+names into the markup and, in trial 1, collided with a `::before` the project
+used for something else. Optional arguments for the item selector and the
+counter name would be additions, not breaks. Trial 2's claim that two nested
+independent counters are impossible was not tested.
+
+### Behaviour changes, for a major version or an opt-in
+
+**`max` includes its breakpoint.** Both. `breakpoint(max, large)` is
+`max-width: 992px` while `min, large` is `min-width: 992px`, so both match at
+992px, and the start/end form subtracts 1 to reach `max-width: 991px`, so the
+library is inconsistent with itself. Trial 1 hand-wrote `991.98px`; trial 2
+wrote `breakpoint("xsmall", "large")` to get 991px. Changing `max` alters every
+existing call at exactly 992px. `-0.02px`, as Bootstrap does, works
+everywhere; range syntax `(width < 992px)` removes the fractional gap
+altogether but needs a newer browser. Related: single-argument
+`breakpoint("medium")` is `(width: 768px)`, documented as exactly that width,
+which almost never matches in practice.
+
+**`columnizer` is flexbox with margins.** Both. Called 1, 2, 3 across
+breakpoints it writes `display: flex` three times and a `box-sizing` block
+three times, and that block targets `.g *`, every descendant, not just the
+columns. Combined with `gap` it overflows; trial 1 added `gap: 0` and trial 2
+did the same in the programme. The margin cascade across breakpoints does work:
+trial 2 checked that a later `:not(:last-child)` overrides the earlier
+`:nth-child(2n)`, and that holds. Scoping `box-sizing` to `> *` or rewriting on
+`gap` changes output that users may rely on.
+
+**`hide("unhide")` writes `position: static`.** Trial 2. A skip link unhidden on
+focus needs `position: fixed` written again afterwards. Leaving `position`
+alone would be more useful and is a change.
+
+**`before` and `after` emit no `content` without an argument.** Trial 1.
+`@include after { ... }` renders nothing. It is deliberate, and said only in
+the error message you see after passing a bad value. A default of
+`content: ""` would mostly be safe, since `@content` comes after it, but not
+entirely.
+
+**`adaptive` does nothing below 576px** and gives one `max-width` per
+breakpoint. Trial 1 wrote its padding by hand. Against the bar in `CLAUDE.md`,
+whether it still earns its place is a fair question; a `@warn` would come
+before any removal.
+
+### Documentation and the manifest
+
+**`loadify(init)` and its calls must share a module.** Trial 2. With `init` in
+one partial and `@include loadify` in another, both loaded from `main.scss`,
+compilation fails with "The target selector was not found". `@use`-ing the
+init module from the calling one fixes it. The manifest example, the `meta/`
+summary and `SKILL.md` all show the two in one file and say nothing about
+modules. Trial 1 escaped it only because its init sat in a module every partial
+forwarded.
+
+**Sass places a nested `@media` before the declarations after it.** Trial 1.
+`.x { @include remove(min, large); display: inline-grid; }` emits the media
+block first, so the later declaration wins at every width. Sass behaviour, not
+the library's, but it bites every mixin that wraps `@content` in a query:
+`breakpoint`, `remove`, `only`, `except`. Only Dart Sass 1.103 and 1.104 were
+checked.
+
+**There is nowhere to put any of these.** The manifest carries
+`name, kind, arguments, file, signature, summary, examples, rejects`. The
+`accepts` text on each argument is prose and never compiled, and there is no
+field for a behavioural caveat, so `SKILL.md` cannot warn an agent about any of
+the traps above. The proposed `caveats` field is in `source-comments.md`.
+
+**The test discipline only runs one way.** `rejects` proves bad input is
+refused. Nothing proves valid modern input is accepted, which is why the
+`var()`, `currentColor` and `null` defects reached a release. `tools/audit.js`
+probes `nonsense`, `16 9`, `true`, `#ff0000`, `42` and `"a b"`, none of which
+is a value that should pass. Two changes would close this: compile the
+`accepts` examples like `examples`, and give the audit a second list of values
+that must be accepted. The audit also shows `triangle` validating the wrong
+argument: strict about `$color`, where it refuses valid CSS, and silent about
+`$size`, where `nonsense` passes straight into `border-width`.
+
+### Candidates for new members
+
+| Need | Trial 1 | Trial 2 |
+|---|---|---|
+| Light and dark tokens | written by hand on `:root` and `[data-theme]` | a `tokens($map)` mixin writing a map to custom properties, over the three states: system preference, forced light, forced dark |
+| `prefers-reduced-motion` guard | | `motion-safe` mixin |
+| Focus ring | `focus-ring($offset)` mixin | written by hand on `:focus-visible` |
+| Section spacing | `section-space()` around `fluid()` | |
+
+`focus-ring` and the reduced-motion guard are already under New members worth
+adding in `CLAUDE.md`, and each now has one trial asking for it independently.
+Token and theme support is the `theme` idea listed there as decorative; two
+trials building it by hand suggests it is not.
+
+---
+
+## What both agents valued
+
+- **`fluid()`**, used 69 times in trial 1 and 32 in trial 2. Trial 1 called it
+  worth installing the library for on its own, and credited the comment that
+  explains why the preferred value keeps a `rem` term.
+- **`container` and `container-query`**, for taking the same argument shapes as
+  `breakpoint`.
+- **`aspect-ratio`, `line-clamp`, `hide`, `stretched-link`**, the members that
+  close something written wrong by hand. Trial 2 applied `aspect-ratio` to the
+  iframe itself, following the source comment.
+- **The error messages**, which name the bad value and the valid ones. Trial 2
+  checked that `hide(nonsense)` and `triangle(sideways)` fail with the library's
+  own message.
+
+Both reached the same description of the library unprompted: fixes for the
+things people get subtly wrong in CSS, documented with what was measured. That
+is the positioning argued for in `verifiable-css-layer.md`.
+
+## Claims the agents got wrong
+
+| Trial | Claim | What is true |
+|---|---|---|
+| 1 | Dart Sass was 1.91.0 | 1.104.1 was installed; 1.91.0 was the range floor in `package.json` |
+| 2 | The `reset-css` comment survives compressed CSS | Absent from both compressed Sass output and the Vite build |
+| 2 | The manifest has no `$name:` example for `container-query` | It has `container-query("min", 400px, $name: "card")` |
+| 2 | Putting the counter reset on the container fixes counters | Still 01 01 01 in the browser |
+
+## Limits
+
+- Two trials, two models, two project types. A change of model and project at
+  once means a difference between the trials cannot be attributed to either.
+- Browser checks were Chromium only.
+- Sass versions before 1.103 were not available locally.
+
+## For the next trial
+
+- Keep the two prompt rules above.
+- Vary the project type again: a data-dense dashboard or a documentation site
+  would exercise what neither portfolio nor conference site did.
+- Re-running trial 2's prompt on Claude Opus 5 would give one prompt under two
+  models, which is the only way to compare the models rather than the projects.
+- After a release carrying the source comments, repeat a prompt with the same
+  model to see whether they change what the agent trips on. See
+  `source-comments.md`.

--- a/todos/source-comments.md
+++ b/todos/source-comments.md
@@ -1,0 +1,97 @@
+# Comments in the library source
+
+Whether the `.scss` files should carry comments written for the people and
+agents who read them, which ones, and in what order.
+
+Measured 13 September 2026 against gerillass v2.1.0, after the first trial
+project in which an agent built a site with the library and wrote feedback on
+it. The trial used Claude Opus 5 and the installed Dart Sass was 1.104.1.
+
+---
+
+## Why this came up
+
+The agent in the trial did not read the documentation site. It read the source
+in `node_modules`, and its feedback quoted source comments by name: the reason
+`fluid` keeps a `rem` term in its preferred value, the note in `container` that
+a query does not match the element it is declared on. It praised those members
+and called that tone of comment what sets the library apart.
+
+The comments are also the one channel that needs no install step. The `.scss`
+files ship in the package, and an agent debugging a call is already reading the
+file the comment sits in.
+
+## What the measurement says
+
+| | Files | With any comment |
+|---|---:|---:|
+| `scss/library` and `scss/utilities` | 78 | 15 |
+| Members the agent praised | 6 | 6 |
+| Members the agent tripped on | 10 | 0 |
+
+Praised, with their comment lines: `fluid` 25, `line-clamp` 16, `aspect-ratio`
+10, `container-query` 9, `container` 8, `loadify` 4.
+
+Tripped on, all at zero: `triangle`, `before`, `after`, `counter`,
+`columnizer`, `adaptive`, `brand-logo`, `position`, `remove`, `breakpoint`.
+
+**Do not read this as cause and effect.** The commented members are also the
+newest and the best designed; the comments and the quality arrived together.
+What the trial does show is that where comments existed, the agent used them.
+
+## Which comments earn their place
+
+The ones the agent quoted all say something the code cannot: why it is written
+this way, the trap it closes, what was measured, what fails without a sound.
+
+The ones that do not earn it restate what the code does or what the signature
+is. That is already in `gerillass.json`, where the suite compiles it. A comment
+repeating it is an unchecked second copy that goes stale, which is the same
+reason `wiki/` is not allowed to restate the API.
+
+## Proposed rules
+
+1. **`//` only, never `/* */`, anywhere in the library.** A block comment
+   inside a mixin is emitted into the user's compiled CSS. This is not a guess:
+   `_reset-css.scss` has two, and both were in the trial's `main.css`, at lines
+   67 and 92. Fix those two as part of this work.
+2. **The comment explains, `meta/` proves.** A behavioural trap goes in the
+   comment for the reader who has the file open, and into `meta/` so it reaches
+   `SKILL.md` and can be checked. `meta/` has no field for that today; the
+   manifest carries `name, kind, arguments, file, signature, summary, examples,
+   rejects` and nothing for caveats. Adding one is a prerequisite for this rule.
+3. **A comment is not a fix.** It is the right tool for behaviour that is
+   deliberate or not the library's to change: `before` with no argument emitting
+   no `content`, Sass placing a nested `@media` before the declarations after
+   it. It is the wrong tool for a defect. `validateLength` warning on `null` and
+   `isColor` rejecting `var()` should be fixed, not annotated.
+4. **Write the convention down.** Neither `CONTRIBUTING.md` nor the `/new-mixin`
+   skill says a word about comments, which is how a new member reproduces the
+   gap.
+
+## Order
+
+1. The ten members the agent tripped on, each comment naming its trap.
+2. The two block comments in `_reset-css.scss`, turned into `//` or removed.
+3. The convention, in `CONTRIBUTING.md` and the `/new-mixin` checklist.
+4. The rest of the library as each file is next touched, not in one pass. A
+   pass over every file at once is the surest way to produce comments that carry
+   nothing.
+
+## How to tell whether it worked
+
+Comments only reach an agent once they are published, since the trials install
+from npm. A trial running while this is written, on Claude Fable 5.1, is
+installing 2.1.0 and will not see anything added to the repository.
+
+To measure the effect, run the same prompt after a release that carries the
+comments and compare what the agent trips on. Hold the prompt and the model
+fixed across the two runs, or a difference cannot be attributed to the
+comments.
+
+## Limits
+
+- The praised and tripped-on lists come from one trial with one model. A second
+  trial may move members between them.
+- Comment lines were counted by pattern (`//`, `/*`, `*` at the start of a
+  line), so a commented-out line of code counts as a comment.

--- a/tools/check-archive.js
+++ b/tools/check-archive.js
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+//
+// What the "Source code" zip on a GitHub release will contain.
+//
+// GitHub builds that zip, and the tarball beside it, with `git archive` from
+// the tagged commit. It never reads .npmignore: only `export-ignore` in
+// .gitattributes keeps a path out. That is how site/ was on its way into the
+// release after 2.1.0 without anyone deciding it should be. It was committed,
+// and nothing looked at the archive.
+//
+// The npm package has its own guard, the published file count in
+// tools/check-docs.js. This is the same idea for the zip, which is meant to
+// differ from the package: the zip is the library's source, buildable and
+// testable, where the package is only what a compiler needs. So the check is
+// an allowlist of top-level entries, and it fails naming anything outside it
+// or anything on it that has gone missing.
+//
+// By default it archives the working tree as the next commit would record it,
+// tracked and untracked files alike, so a change to .gitattributes can be
+// checked before it is committed. `--ref` archives a commit or tag instead.
+//
+// Usage: node tools/check-archive.js [--ref v2.1.0]
+
+const { execFileSync } = require("child_process");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const ROOT = path.resolve(__dirname, "..");
+
+const EXPECTED = [
+  // The library and what builds, describes and tests it.
+  "scss",
+  "meta",
+  "test",
+  "tools",
+  "assets",
+  "package.json",
+  "yarn.lock",
+  "gerillass.json",
+  "SKILL.md",
+  "llms.txt",
+
+  // Documents a user or a contributor reads.
+  "README.md",
+  "LICENSE.md",
+  "CHANGELOG.md",
+  "MIGRATION.md",
+  "CONTRIBUTING.md",
+  "CODE_OF_CONDUCT.md",
+
+  // How the repository is worked on.
+  "CLAUDE.md",
+  ".claude",
+  ".github",
+  ".nvmrc",
+  ".gitignore",
+  ".npmignore",
+  ".gitattributes",
+];
+
+const git = (args, env = {}) =>
+  execFileSync("git", args, {
+    cwd: ROOT,
+    env: { ...process.env, ...env },
+    maxBuffer: 256 * 1024 * 1024,
+  });
+
+function workingTree() {
+  // A throwaway index, so the real one is never touched.
+  const index = path.join(os.tmpdir(), `gerillass-check-archive-${process.pid}`);
+  const env = { GIT_INDEX_FILE: index };
+  try {
+    git(["read-tree", "HEAD"], env);
+    git(["add", "-A"], env);
+    return git(["write-tree"], env).toString().trim();
+  } finally {
+    fs.rmSync(index, { force: true });
+  }
+}
+
+const refAt = process.argv.indexOf("--ref");
+const treeish = refAt === -1 ? workingTree() : process.argv[refAt + 1];
+const label = refAt === -1 ? "the working tree" : treeish;
+
+if (!treeish) {
+  console.error("--ref needs a commit or a tag, e.g. --ref v2.1.0");
+  process.exit(2);
+}
+
+const tar = git(["archive", "--format=tar", treeish]);
+const entries = execFileSync("tar", ["-t"], { input: tar, maxBuffer: 64 * 1024 * 1024 })
+  .toString()
+  .split("\n")
+  .filter(Boolean);
+
+const files = entries.filter((e) => !e.endsWith("/"));
+const found = new Set(entries.map((e) => e.split("/")[0]));
+
+const unexpected = [...found].filter((e) => !EXPECTED.includes(e)).sort();
+const missing = EXPECTED.filter((e) => !found.has(e));
+
+if (!unexpected.length && !missing.length) {
+  console.log(`Release archive of ${label}: ${files.length} files, only the expected entries.`);
+  process.exit(0);
+}
+
+console.error(`Release archive of ${label} does not match what a release should carry:\n`);
+for (const e of unexpected) {
+  const count = files.filter((f) => f === e || f.startsWith(`${e}/`)).length;
+  console.error(`  unexpected  ${e}  (${count} ${count === 1 ? "file" : "files"})`);
+}
+for (const e of missing) {
+  console.error(`  missing     ${e}`);
+}
+console.error(
+  "\nKeep an unexpected path out with `<path> export-ignore` in .gitattributes, " +
+    "or add it to EXPECTED in this file if it belongs in the zip. " +
+    "A missing entry was deleted, renamed, or excluded by mistake."
+);
+process.exit(1);


### PR DESCRIPTION
The "Source code" zip and tarball GitHub attaches to a release are built with `git archive` from the tag, and `.npmignore` does not reach them. Nothing looked at them, so `site/`, 532 files of another product, was on its way into the first release after 2.1.0 without anyone deciding it.

`.gitattributes` now marks `site`, `netlify.toml`, `wiki` and `todos` as `export-ignore`. The zip is meant to differ from the npm package: it is the library's buildable, testable source, so `meta`, `test` and `tools` stay in it. The next release's zip is 228 files, against 763 without this.

`tools/check-archive.js` holds the list of what the zip should carry and fails on anything outside it or missing from it. By default it archives the working tree as the next commit would record it, so it can be run before committing; `--ref` checks a tag. Against HEAD before this commit it fails naming exactly the four paths above. The release skill runs it before tagging.

`todos` is also listed in `.npmignore` outright. The `*.md` rule was covering it only because everything in it happened to be Markdown.

Two new files in `todos/` record research not yet acted on:

- `agent-trials.md`: two projects built from scratch with the published package by two different models, every claim in their feedback checked here by compiling it, sorted into fixes that break nothing, behaviour changes, and gaps in the documentation and manifest.
- `source-comments.md`: the agents read the source rather than the docs, every member they praised was commented and every one they tripped on was not; which comments to write, and in what order.