### PR TITLE
Add the groundwork the 2.1.1 fixes will be tested against

### DIFF
--- a/.claude/skills/audit-library/SKILL.md
+++ b/.claude/skills/audit-library/SKILL.md
@@ -48,6 +48,13 @@ a sentence naming what the argument accepts. Fix by checking the type before
 reaching for `str-slice`, `nth` or `unit`. Sass's own `Missing argument $name` is
 not in this bucket: it names the argument, which is enough.
 
+Sass's arithmetic errors, `Undefined operation` and `can't be used in a
+calculation`, belong here too. The tool missed them until the groundwork for
+2.1.1, and recognising them raised this bucket from 0 to 39: `background-dots`,
+`background-stripes` and `triangle` doing maths on their sizes, and the utility
+functions `remify`, `fontSizer`, `clearUnit`, `convertToEm` and
+`convertToNumber`. They are F9 and F11 in `todos/fix-plan.md`.
+
 **WARNED ONLY — the build succeeded with a warning.** A warning most pipelines
 never surface. Today all of these are `validateLength` on a value that is not
 a length, six of them reached through `position`, and they stay warnings on
@@ -59,6 +66,17 @@ act on the count. Some are correct — `after(nonsense)` really should emit
 `content: "nonsense"`. Others are real, like a colour argument that lands in the
 CSS as the literal word `true`. The question to ask is whether the emitted value
 could ever be valid CSS.
+
+The sweep then runs again with four values CSS does take, `var(--x)`,
+`currentColor`, `null` and `calc(1rem + 2px)`, into two buckets of their own:
+
+**REFUSED VALID CSS — raised on a value CSS takes.** A report, not a gate. A
+keyword argument, a selector or a size in a media condition is right to refuse
+`var()`. A colour, a length or a `content` value usually is not.
+
+**BROKEN OUTPUT — compiled, but the CSS cannot work.** Always a defect: `var()`
+inside `url()`, `var()` inside a quoted string, or a `/` division Sass left
+unevaluated, such as `var(--x)/2`.
 
 ### False positives this probe has hit before
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,7 +179,8 @@ loop in `/release` because the loop got skipped, and v2.1.0 shipped with
 **What keeps them honest is `test/manifest.spec.js`**, and this is the whole
 point of the design:
 
-- every `examples` entry in `meta/` is compiled **and snapshotted**
+- every `examples` entry in `meta/` is compiled **and snapshotted**, and must
+  not print a `@warn`
 - every `rejects` entry must actually `@error`, and must fail with the library's
   own message rather than a Sass internal error
 - every example runs again under its `gls-` name and must produce byte-identical
@@ -191,6 +192,12 @@ A mixin with no `meta/` entry fails the suite, so metadata is not optional.
 So the manifest cannot claim behaviour the library does not have. When you add
 or change a mixin, write its `meta/` entry in the same commit: the `rejects`
 list is where the mixin's validation gets its test coverage.
+
+One field is not executed: `caveats`, for behaviour a signature cannot show,
+such as `loadify` failing across modules or `breakpoint` with one argument
+matching a single pixel. `build-manifest.js` copies it and `SKILL.md` lists it
+under "Traps a signature does not show". Because nothing checks it, write a
+caveat only from a case you compiled or measured.
 
 ## Architecture
 
@@ -301,7 +308,11 @@ members that compute something — `triangle`, `scissors`, `columnizer`,
 
 `node tools/audit.js` is the fourth thing the suite cannot do: it throws
 arguments nobody wrote a test for at every member and every argument position.
-Its SILENT and UNHELPFUL buckets must stay empty.
+Its SILENT bucket must stay empty. UNHELPFUL must too, and was until the audit
+learned to recognise Sass's arithmetic errors: it now lists 39, which are F9 and
+F11 in `todos/fix-plan.md`. A second sweep passes values CSS does take, such as
+`var(--x)`: REFUSED VALID CSS is a report to read, since a keyword argument is
+right to refuse one, and BROKEN OUTPUT is always a defect, 13 of them today.
 
 ## Conventions
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -102,6 +102,42 @@ a dropped declaration rather than an error.
 | `text-shadow` | `.a { @include text-shadow(42); }` |
 | `triangle` | `.caret { @include triangle(sideways); }` |
 
+## Traps a signature does not show
+
+**`after`**
+
+- With no argument no `content` is emitted, so the pseudo-element does not render unless the block sets `content`. Pass `""` for an empty one.
+
+**`aspect-ratio`**
+
+- On an element with a `height` attribute, such as `<img width="1600" height="900">` or an embed code's `<iframe>`, the attribute height wins and the ratio is ignored. Write `height: auto` after the include.
+
+**`before`**
+
+- With no argument no `content` is emitted, so the pseudo-element does not render unless the block sets `content`. Pass `""` for an empty one.
+
+**`breakpoint`**
+
+- With one argument the query matches exactly that width, `(width: 768px)`, which is a single pixel. Use `min`, `max` or a range for anything wider.
+- Declarations written after the include, in the same rule, are emitted after the `@media` block and win over it. Write them before the include.
+
+**`container`**
+
+- An element does not match a `@container` query that reads its own container, and nothing warns. Put the `container-query` on a descendant.
+
+**`counter`**
+
+- Numbering restarts on every item, each showing the first number, when the items are size containers (`container-type: inline-size`): containment scopes counters to each item.
+
+**`loadify`**
+
+- `init` and every call must be in the same module, or the module with the call must `@use` the one that calls `init`. Otherwise Sass fails with "The target selector was not found".
+
+**`remove`**
+
+- With one argument the element is hidden at exactly that width, `(width: 768px)`, which is a single pixel. Use `min`, `max` or a range for anything wider.
+- A `display` written after the include, in the same rule, is emitted after the `@media` block and wins over it. Write it before the include.
+
 ## Mixins
 
 | Signature | What it does |

--- a/gerillass.json
+++ b/gerillass.json
@@ -49,6 +49,9 @@
       "file": "scss/library/_after.scss",
       "signature": "after($content: null)",
       "summary": "Styles the ::after pseudo-element. A `data-` argument becomes an attr() content value.",
+      "caveats": [
+        "With no argument no `content` is emitted, so the pseudo-element does not render unless the block sets `content`. Pass `\"\"` for an empty one."
+      ],
       "examples": [
         ".a { @include after(\"→\") { color: red; } }",
         ".a { @include after(\"data-label\") { color: red; } }",
@@ -170,6 +173,9 @@
       "file": "scss/library/_aspect-ratio.scss",
       "signature": "aspect-ratio($ratio: null, $fit: cover)",
       "summary": "Holds an element to a ratio and adds what CSS aspect-ratio alone leaves out: object-fit so an image is cropped rather than stretched, and border: 0 so an iframe does not overflow its container by 4px. Apply it to the element itself, not to a wrapper.",
+      "caveats": [
+        "On an element with a `height` attribute, such as `<img width=\"1600\" height=\"900\">` or an embed code's `<iframe>`, the attribute height wins and the ratio is ignored. Write `height: auto` after the include."
+      ],
       "examples": [
         ".thumb { @include aspect-ratio(\"16:9\"); }",
         ".video { @include aspect-ratio(\"16/9\"); }",
@@ -341,6 +347,9 @@
       "file": "scss/library/_before.scss",
       "signature": "before($content: null)",
       "summary": "Styles the ::before pseudo-element. A `data-` argument becomes an attr() content value.",
+      "caveats": [
+        "With no argument no `content` is emitted, so the pseudo-element does not render unless the block sets `content`. Pass `\"\"` for an empty one."
+      ],
       "examples": [
         ".a { @include before(\"→\") { color: red; } }",
         ".a { @include before(\"data-label\") { color: red; } }"
@@ -453,6 +462,10 @@
       "file": "scss/library/_breakpoint.scss",
       "signature": "breakpoint($params...)",
       "summary": "Media query built from the breakpoint map, or from raw lengths.",
+      "caveats": [
+        "With one argument the query matches exactly that width, `(width: 768px)`, which is a single pixel. Use `min`, `max` or a range for anything wider.",
+        "Declarations written after the include, in the same rule, are emitted after the `@media` block and win over it. Write them before the include."
+      ],
       "examples": [
         ".a { @include breakpoint(\"medium\") { color: red; } }",
         ".a { @include breakpoint(\"min\", \"medium\") { color: red; } }",
@@ -627,6 +640,9 @@
       "file": "scss/library/_container.scss",
       "signature": "container($name: null, $type: inline-size)",
       "summary": "Marks an element as a query container, so container-query can ask about its width instead of the viewport's. The rule that asks has to sit on a descendant: an element is never matched by a @container rule reading its own container, and nothing warns you when it is not.",
+      "caveats": [
+        "An element does not match a `@container` query that reads its own container, and nothing warns. Put the `container-query` on a descendant."
+      ],
       "examples": [
         ".card { @include container(\"card\"); }",
         ".panel { @include container; }",
@@ -654,6 +670,9 @@
       "file": "scss/library/_counter.scss",
       "signature": "counter($params...)",
       "summary": "CSS counter for a list, with optional text before and after the number.",
+      "caveats": [
+        "Numbering restarts on every item, each showing the first number, when the items are size containers (`container-type: inline-size`): containment scopes counters to each item."
+      ],
       "examples": [
         ".list { @include counter(\"decimal\"); }",
         ".list { @include counter(\".\"); }",
@@ -892,6 +911,9 @@
       "file": "scss/library/_loadify.scss",
       "signature": "loadify($params...)",
       "summary": "Fades elements in on page load. Call once at the root to set up, then on each element. Under prefers-reduced-motion: reduce the end state is applied directly and no animation runs. Switching the animation off alone would not do, because the element starts invisible and the animation is what reveals it, so the content would stay hidden for good.",
+      "caveats": [
+        "`init` and every call must be in the same module, or the module with the call must `@use` the one that calls `init`. Otherwise Sass fails with \"The target selector was not found\"."
+      ],
       "examples": [
         "@include loadify(init);\n.a { @include loadify; }",
         "@include loadify;\n.a { @include loadify(0.4s, 1s); }"
@@ -1035,6 +1057,10 @@
       "file": "scss/library/_remove.scss",
       "signature": "remove($params...)",
       "summary": "Hides an element outright, or only within a breakpoint range.",
+      "caveats": [
+        "With one argument the element is hidden at exactly that width, `(width: 768px)`, which is a single pixel. Use `min`, `max` or a range for anything wider.",
+        "A `display` written after the include, in the same rule, is emitted after the `@media` block and wins over it. Write it before the include."
+      ],
       "examples": [
         ".a { @include remove; }",
         ".a { @include remove(\"medium\"); }",

--- a/meta/after.json
+++ b/meta/after.json
@@ -1,6 +1,9 @@
 {
   "name": "after",
   "summary": "Styles the ::after pseudo-element. A `data-` argument becomes an attr() content value.",
+  "caveats": [
+    "With no argument no `content` is emitted, so the pseudo-element does not render unless the block sets `content`. Pass `\"\"` for an empty one."
+  ],
   "arguments": [
     {
       "name": "$content",

--- a/meta/aspect-ratio.json
+++ b/meta/aspect-ratio.json
@@ -1,6 +1,9 @@
 {
   "name": "aspect-ratio",
   "summary": "Holds an element to a ratio and adds what CSS aspect-ratio alone leaves out: object-fit so an image is cropped rather than stretched, and border: 0 so an iframe does not overflow its container by 4px. Apply it to the element itself, not to a wrapper.",
+  "caveats": [
+    "On an element with a `height` attribute, such as `<img width=\"1600\" height=\"900\">` or an embed code's `<iframe>`, the attribute height wins and the ratio is ignored. Write `height: auto` after the include."
+  ],
   "arguments": [
     {
       "name": "$ratio",

--- a/meta/before.json
+++ b/meta/before.json
@@ -1,6 +1,9 @@
 {
   "name": "before",
   "summary": "Styles the ::before pseudo-element. A `data-` argument becomes an attr() content value.",
+  "caveats": [
+    "With no argument no `content` is emitted, so the pseudo-element does not render unless the block sets `content`. Pass `\"\"` for an empty one."
+  ],
   "arguments": [
     {
       "name": "$content",

--- a/meta/breakpoint.json
+++ b/meta/breakpoint.json
@@ -1,6 +1,10 @@
 {
   "name": "breakpoint",
   "summary": "Media query built from the breakpoint map, or from raw lengths.",
+  "caveats": [
+    "With one argument the query matches exactly that width, `(width: 768px)`, which is a single pixel. Use `min`, `max` or a range for anything wider.",
+    "Declarations written after the include, in the same rule, are emitted after the `@media` block and win over it. Write them before the include."
+  ],
   "arguments": [
     {
       "name": "$params",

--- a/meta/container.json
+++ b/meta/container.json
@@ -1,6 +1,9 @@
 {
   "name": "container",
   "summary": "Marks an element as a query container, so container-query can ask about its width instead of the viewport's. The rule that asks has to sit on a descendant: an element is never matched by a @container rule reading its own container, and nothing warns you when it is not.",
+  "caveats": [
+    "An element does not match a `@container` query that reads its own container, and nothing warns. Put the `container-query` on a descendant."
+  ],
   "arguments": [
     { "name": "$name", "accepts": ["a container name as a string, such as \"card\"", "null for an unnamed container"] },
     { "name": "$type", "accepts": ["inline-size", "size", "normal"] }

--- a/meta/counter.json
+++ b/meta/counter.json
@@ -1,6 +1,9 @@
 {
   "name": "counter",
   "summary": "CSS counter for a list, with optional text before and after the number.",
+  "caveats": [
+    "Numbering restarts on every item, each showing the first number, when the items are size containers (`container-type: inline-size`): containment scopes counters to each item."
+  ],
   "arguments": [
     {
       "name": "$params",

--- a/meta/loadify.json
+++ b/meta/loadify.json
@@ -1,6 +1,9 @@
 {
   "name": "loadify",
   "summary": "Fades elements in on page load. Call once at the root to set up, then on each element. Under prefers-reduced-motion: reduce the end state is applied directly and no animation runs. Switching the animation off alone would not do, because the element starts invisible and the animation is what reveals it, so the content would stay hidden for good.",
+  "caveats": [
+    "`init` and every call must be in the same module, or the module with the call must `@use` the one that calls `init`. Otherwise Sass fails with \"The target selector was not found\"."
+  ],
   "arguments": [
     {
       "name": "$params",

--- a/meta/remove.json
+++ b/meta/remove.json
@@ -1,6 +1,10 @@
 {
   "name": "remove",
   "summary": "Hides an element outright, or only within a breakpoint range.",
+  "caveats": [
+    "With one argument the element is hidden at exactly that width, `(width: 768px)`, which is a single pixel. Use `min`, `max` or a range for anything wider.",
+    "A `display` written after the include, in the same rule, is emitted after the `@media` block and wins over it. Write it before the include."
+  ],
   "arguments": [
     {
       "name": "$params",

--- a/test/manifest.spec.js
+++ b/test/manifest.spec.js
@@ -20,8 +20,19 @@ const SASS_OPTS = {
   silenceDeprecations: ["if-function"],
 };
 
-const compile = (snippet) =>
-  sass.compileString(`@use "gerillass" as *;\n${snippet}\n`, SASS_OPTS);
+// Pass an array to collect @warn messages. Deprecations are left out: they are
+// silenced above for a reason recorded in CLAUDE.md, and would fail every test.
+const compile = (snippet, warnings) =>
+  sass.compileString(`@use "gerillass" as *;\n${snippet}\n`, {
+    ...SASS_OPTS,
+    ...(warnings && {
+      logger: {
+        warn(message, { deprecation }) {
+          if (!deprecation) warnings.push(message);
+        },
+      },
+    }),
+  });
 
 const mixins = manifest.members.filter((m) => m.kind === "mixin");
 
@@ -77,11 +88,17 @@ describe("Manifest", () => {
 // into a reviewable diff. A snapshot records what the library does, not what it
 // ought to do -- the sass-true specs under test/library are where correctness
 // is asserted by hand.
+//
+// A documented call must also compile without a @warn. The CSS can be right
+// while the build prints a warning on every compile: `position` did that for
+// `null`, the way its own documentation page skips an edge, and passed.
 describe("Manifest examples", () => {
   for (const member of manifest.members) {
     for (const example of member.examples || []) {
       it(`${member.name}: ${example.replace(/\s+/g, " ").slice(0, 70)}`, () => {
-        const result = compile(example);
+        const warnings = [];
+        const result = compile(example, warnings);
+        expect(warnings).toEqual([]);
         expect(result.css.length).toBeGreaterThan(0);
         expect(result.css).toMatchSnapshot();
       });

--- a/todos/fix-plan.md
+++ b/todos/fix-plan.md
@@ -46,6 +46,7 @@ see G4.
 | F8 | Values that end up in a declaration let a CSS function through | 2.1.1 | probe |
 | F9 | Computed sizes work with `var()`, `calc()` and `clamp()` | 2.1.1 | probe |
 | F10 | `background-image` and `font-face` stop dropping values silently | 2.1.1 | probe |
+| F11 | Utility functions refuse non-numbers with their own message | 2.1.1 | audit |
 | D1 | Document the `loadify` module rule | 2.1.1 | T2 |
 | D2 | Correct the `remove` summary and example | 2.1.1 | T2 T3 |
 | D3 | A Parcel section in the README | 2.1.1 | T3 |
@@ -80,6 +81,9 @@ under Modernisation in `CLAUDE.md`, and the comments in the source are in
 ---
 
 ## Groundwork
+
+**Status.** G1 to G4 are implemented. What each one found when it landed is
+recorded under it; the sections stay because the fixes below refer to them.
 
 ### G1. Fail the manifest suite when an example warns
 
@@ -125,7 +129,9 @@ expect(warnings).toEqual([]);
 **Touches.** `test/manifest.spec.js`.
 
 **Verify.** Add the `null` example above to `meta/position.json`. The suite
-must fail before F2 and pass after it.
+must fail before F2 and pass after it. Done when G1 landed: with the example
+added temporarily the test failed on the empty-message warning, and passed
+again once it was removed.
 
 **Validated.** None of the 143 examples in `meta/` prints a warning today, so
 turning this on does not fail the suite by itself.
@@ -262,8 +268,10 @@ reports none of them:
 **Fix.**
 
 1. Add `Undefined operation` and `can't be used in a calculation` to `INTERNAL`.
-   Expect new UNHELPFUL findings for `background-dots` and `background-stripes`
-   until F9 lands.
+   The plan expected new UNHELPFUL findings for `background-dots` and
+   `background-stripes` only. Landing it found 39: those two (15), `triangle`
+   with a colour as its size (1), and five utility functions doing arithmetic on
+   whatever they are given (23). F9 covers the first 16; the functions are F11.
 2. Extend the second probe list from G2 with a check on the output, not only the
    compile: flag CSS containing `url(var(`, `"var(`, or `var(` next to `/` outside
    a `calc()`, in a new "broken output" bucket.
@@ -277,6 +285,12 @@ buckets.
 
 **Verify.** Before F8 to F10: the new buckets list the cases above. After: they are
 empty, apart from what F4 turns into refusals.
+
+When it landed, BROKEN OUTPUT listed 13: the F8 and F9 cases, plus two not
+predicted. `font-face` with a `var()` `$file-path` emits `url("var(--x).eot")`,
+and `convertToEm(var(--x))` emits `var(--x)/16pxem`. F10's format check does not
+catch the first, since the formats themselves are valid, so give `$file-path` its
+own check in F10. The second is F11.
 
 ---
 
@@ -733,6 +747,44 @@ raises too, which is right: a format list is chosen at compile time.
 unchanged, and 57 probe calls moved from CSS that could not work to the new
 errors. One message needs care: `$file-formats: null` prints empty backticks, so
 name `null` explicitly.
+
+### F11. Utility functions refuse non-numbers with their own message
+
+**Problem.** Five public functions do arithmetic on their argument without
+checking it, so anything that is not a number fails inside Sass, or worse,
+compiles. Found by the audit once G4 taught it Sass's arithmetic errors.
+
+| Function | Given | Today |
+|---|---|---|
+| `remify` | `nonsense` | `Undefined operation "nonsense/16px * 1rem"` |
+| `fontSizer` | `nonsense` | `Undefined operation "nonsense * 10px"` |
+| `clearUnit` | `nonsense` | `Undefined operation "nonsense * 0"` |
+| `convertToNumber` | `nonsense` | `Undefined operation "0-1 * 10"` |
+| `convertToEm` | `#ff0000` | `Undefined operation "#ff0000 / 16px"` |
+| `convertToEm` | `var(--x)` | compiles to `var(--x)/16pxem` |
+
+These are called by users directly; `remify` has its own documentation page.
+
+**Fix.** A type check at the top of each, with a message naming what it takes,
+in the style the mixins already use:
+
+```scss
+@if meta.type-of($value) != "number" {
+  @error "`#{$value}` is not a valid $value for `remify`. Pass a number, such as `24px` or `24`.";
+}
+```
+
+`convertToNumber` parses strings, so its check belongs where the parse fails,
+not on the type.
+
+**Changes existing output?** No working call changes: every row above is an error
+or unusable CSS today. `convertToEm(var(--x))` goes from broken CSS to an error.
+
+**Touches.** `scss/utilities/_remify.scss`, `_font-sizer.scss`, `_clear-unit.scss`,
+`_convert-to-number.scss`, `_convert-to-em.scss`; a reject in each `meta/` file.
+
+**Verify.** `node tools/audit.js` shows none of these five in UNHELPFUL or BROKEN
+OUTPUT. Nothing here has been prototyped yet.
 
 ### D1. Document the `loadify` module rule
 

--- a/tools/audit.js
+++ b/tools/audit.js
@@ -40,6 +40,17 @@ let lastWarning = null;
 // not open: a space separated list, a bool, a colour, a bare number, a word.
 const PROBES = ["nonsense", "16 9", "true", "#ff0000", "42", '"a b"'];
 
+// The other direction: values modern CSS takes that a mixin might wrongly
+// refuse, or accept and mangle. These feed their own two buckets and none of
+// the four above, because a refusal here is often right -- a keyword argument
+// or a size in a media condition must not take var() -- and a real error is no
+// finding for a bad value but may be one for a valid one.
+const VALID_PROBES = ["var(--x)", "currentColor", "null", "calc(1rem + 2px)"];
+
+// Output that compiled but cannot work: var() inside url(), var() inside a
+// quoted string, and a slash division Sass could not evaluate.
+const BROKEN = /url\(\s*var\(|["']var\(|(var\(--x\)|calc\(1rem \+ 2px\))\/\S/;
+
 function run(snippet) {
   lastWarning = null;
   try {
@@ -54,12 +65,12 @@ function run(snippet) {
 // the caller nothing about what the mixin wanted. Sass's own "Missing argument
 // $name" is excluded on purpose: it names the argument, which is all a caller
 // needs.
-const INTERNAL = /is not a string|Invalid index|\$number: .* is not a number|no element|Undefined (variable|mixin)|expected (a |an )?["'a-z]/i;
+const INTERNAL = /is not a string|Invalid index|\$number: .* is not a number|no element|Undefined (variable|mixin|operation)|can't be used in a calculation|expected (a |an )?["'a-z]/i;
 
 const only = process.argv.slice(2);
 const members = manifest.members.filter((m) => !only.length || only.includes(m.name));
 
-const findings = { silent: [], internal: [], warned: [], passthrough: [] };
+const findings = { silent: [], internal: [], warned: [], passthrough: [], refused: [], broken: [] };
 
 for (const m of members) {
   // A member that takes no arguments has nothing to probe.
@@ -113,7 +124,8 @@ for (const m of members) {
   })();
 
   for (const pos of positions) {
-    for (const probe of PROBES) {
+    for (const probe of [...PROBES, ...VALID_PROBES]) {
+      const valid = VALID_PROBES.includes(probe);
       const target = m.arguments[pos];
       // A variadic argument cannot be named -- `$params: x` would be read as a
       // keyword argument rather than a value -- so it stays positional.
@@ -141,6 +153,17 @@ for (const m of members) {
       }
       const result = run(snippet);
 
+      if (valid) {
+        // Sass's own "Missing argument" is about the filler, not the probe.
+        if (!result.ok && !/Missing argument/.test(result.message)) {
+          findings.refused.push({ mixin: label, message: result.message.slice(0, 90) });
+        } else if (result.ok && BROKEN.test(result.css)) {
+          const at = result.css.split("\n").find((l) => BROKEN.test(l)).trim();
+          findings.broken.push({ mixin: label, css: at.slice(0, 70) });
+        }
+        continue;
+      }
+
       if (!result.ok) {
         if (INTERNAL.test(result.message)) {
           findings.internal.push({ mixin: label, probe, message: result.message.slice(0, 90) });
@@ -158,7 +181,10 @@ const line = (s) => console.log(s);
 
 const nMixins = members.filter((m) => m.kind === "mixin").length;
 const nFns = members.filter((m) => m.kind === "function").length;
-line(`Probed ${nMixins} mixins and ${nFns} functions, every argument position, ${PROBES.length} bad values each.\n`);
+line(
+  `Probed ${nMixins} mixins and ${nFns} functions, every argument position, ` +
+    `${PROBES.length} bad values and ${VALID_PROBES.length} valid CSS values each.\n`
+);
 
 line(`SILENT — produced no CSS and no error (${findings.silent.length})`);
 if (!findings.silent.length) line("  none");
@@ -176,7 +202,17 @@ line(`\nPASSED THROUGH — emitted CSS from a questionable argument (${findings.
 if (!findings.passthrough.length) line("  none");
 for (const f of findings.passthrough) line(`  ${f.mixin}  ${f.css}`);
 
+line(`\nREFUSED VALID CSS — raised on ${VALID_PROBES.join(", ")} (${findings.refused.length})`);
+if (!findings.refused.length) line("  none");
+for (const f of findings.refused) line(`  ${f.mixin}  ${f.message}`);
+
+line(`\nBROKEN OUTPUT — compiled, but the CSS cannot work (${findings.broken.length})`);
+if (!findings.broken.length) line("  none");
+for (const f of findings.broken) line(`  ${f.mixin}  ${f.css}`);
+
 line(
   `\nSilence is always a defect. An unhelpful error is a missing type check. ` +
-    `Pass-through is only a defect when the value cannot be valid CSS -- review, do not assume.`
+    `Pass-through is only a defect when the value cannot be valid CSS -- review, do not assume. ` +
+    `A refused valid value is a defect only where CSS would take it: a keyword or a size in a ` +
+    `media condition is right to refuse var(). Broken output is always a defect.`
 );

--- a/tools/build-manifest.js
+++ b/tools/build-manifest.js
@@ -144,6 +144,7 @@ function build() {
     const m = meta[member.name];
     if (!m) continue;
     if (m.summary) member.summary = m.summary;
+    if (m.caveats) member.caveats = m.caveats;
     if (m.examples) member.examples = m.examples;
     if (m.rejects) member.rejects = m.rejects;
     if (m.arguments) {

--- a/tools/build-skill.js
+++ b/tools/build-skill.js
@@ -25,6 +25,17 @@ const tricky = mixins.filter((m) => m.rejects && m.rejects.length);
 
 const row = (m) => `| \`${m.signature}\` | ${m.summary} |`;
 
+// Behaviour a signature cannot show: what fails silently, or in a way the call
+// gives no hint of. Authored as `caveats` in meta/ and omitted when none exist.
+const withCaveats = manifest.members.filter((m) => m.caveats && m.caveats.length);
+const caveats = withCaveats.length
+  ? `
+## Traps a signature does not show
+
+${withCaveats.map((m) => `**\`${m.name}\`**\n\n${m.caveats.map((c) => `- ${c}`).join("\n")}`).join("\n\n")}
+`
+  : "";
+
 const out = `---
 name: gerillass
 description: Use the Gerillass Sass mixin library — loading it, the mixin catalogue, and the argument forms that are easy to get wrong. Use when writing SCSS in a project that has gerillass installed.
@@ -93,7 +104,7 @@ a dropped declaration rather than an error.
 | Mixin | Rejects, for example |
 |---|---|
 ${tricky.map((m) => `| \`${m.name}\` | \`${m.rejects[0].replace(/\|/g, "\\|")}\` |`).join("\n")}
-
+${caveats}
 ## Mixins
 
 | Signature | What it does |


### PR DESCRIPTION
- The manifest suite fails when a documented example prints a @warn.
- The audit recognises Sass's arithmetic errors, and runs a second sweep with values CSS accepts, reporting refusals and output that cannot work.
- meta/ gains a caveats field, copied into gerillass.json and listed in SKILL.md, with eight verified caveats.

The audit now reports 39 unhelpful errors it could not see before and 13 broken outputs; the plan tracks them as F8 to F11.