### PR TITLE
Keep reset-css's comments out of compiled CSS

### DIFF
--- a/scss/library/_reset-css.scss
+++ b/scss/library/_reset-css.scss
@@ -4,10 +4,12 @@
     @if & {
         @error "Please call the mixin at the root of your style sheet.";
     } @else {
-    /* http://meyerweb.com/eric/tools/css/reset/ 
-    v2.0 | 20110126
-    License: none (public domain)
-    */
+    // http://meyerweb.com/eric/tools/css/reset/
+    // v2.0 | 20110126
+    // License: none (public domain)
+    //
+    // Comments in this file are `//`: a /* */ comment inside a mixin is emitted
+    // into the stylesheet of everyone who includes it.
     html, body, div, span, applet, object, iframe,
     h1, h2, h3, h4, h5, h6, p, blockquote, pre,
     a, abbr, acronym, address, big, cite, code,
@@ -28,7 +30,7 @@
       font: inherit;
       vertical-align: baseline;
     }
-    /* HTML5 display-role reset for older browsers */
+    // HTML5 display-role reset for older browsers
     article, aside, details, figcaption, figure, 
     footer, header, hgroup, menu, main, nav, section {
       display: block;

--- a/test/__snapshots__/manifest.spec.js.snap
+++ b/test/__snapshots__/manifest.spec.js.snap
@@ -1048,11 +1048,7 @@ exports[`Manifest examples remove: .a { @include remove; } 1`] = `
 `;
 
 exports[`Manifest examples reset-css: @include reset-css; 1`] = `
-"/* http://meyerweb.com/eric/tools/css/reset/ 
-v2.0 | 20110126
-License: none (public domain)
-*/
-html, body, div, span, applet, object, iframe,
+"html, body, div, span, applet, object, iframe,
 h1, h2, h3, h4, h5, h6, p, blockquote, pre,
 a, abbr, acronym, address, big, cite, code,
 del, dfn, em, img, ins, kbd, q, s, samp,
@@ -1073,7 +1069,6 @@ time, mark, audio, video {
   vertical-align: baseline;
 }
 
-/* HTML5 display-role reset for older browsers */
 article, aside, details, figcaption, figure,
 footer, header, hgroup, menu, main, nav, section {
   display: block;

--- a/test/manifest.spec.js
+++ b/test/manifest.spec.js
@@ -92,6 +92,10 @@ describe("Manifest", () => {
 // A documented call must also compile without a @warn. The CSS can be right
 // while the build prints a warning on every compile: `position` did that for
 // `null`, the way its own documentation page skips an edge, and passed.
+//
+// And without a /* */ comment. Inside a mixin one is emitted into the user's
+// stylesheet, which is how the Meyer licence note from `reset-css` ended up in
+// projects' compiled CSS. Library comments are `//`.
 describe("Manifest examples", () => {
   for (const member of manifest.members) {
     for (const example of member.examples || []) {
@@ -99,6 +103,7 @@ describe("Manifest examples", () => {
         const warnings = [];
         const result = compile(example, warnings);
         expect(warnings).toEqual([]);
+        expect(result.css).not.toMatch(/\/\*/);
         expect(result.css.length).toBeGreaterThan(0);
         expect(result.css).toMatchSnapshot();
       });

--- a/todos/fix-plan.md
+++ b/todos/fix-plan.md
@@ -563,6 +563,10 @@ of `source-comments.md`: `//` only, everywhere in the library.
 
 **Verify.** `grep -c meyerweb` on a compiled expanded file returns 0.
 
+**Status.** Implemented. The manifest suite now also fails any documented
+example whose CSS contains a `/*` comment, which failed on `reset-css` alone
+before the change.
+
 ### F8. Values that end up in a declaration let a CSS function through
 
 **Problem.** Eight arguments turn a `var()` into CSS that looks right and does

--- a/todos/source-comments.md
+++ b/todos/source-comments.md
@@ -72,7 +72,9 @@ reason `wiki/` is not allowed to restate the API.
 ## Order
 
 1. The ten members the agent tripped on, each comment naming its trap.
-2. The two block comments in `_reset-css.scss`, turned into `//` or removed.
+2. ~~The two block comments in `_reset-css.scss`, turned into `//` or removed.~~
+   Done as F7 in `fix-plan.md`, with a test that fails on any `/*` in an example's
+   CSS.
 3. The convention, in `CONTRIBUTING.md` and the `/new-mixin` checklist.
 4. The rest of the library as each file is next touched, not in one pass. A
    pass over every file at once is the surest way to produce comments that carry


### PR DESCRIPTION
The Meyer licence note and the display-role note were /* */ comments inside the mixin, so they were emitted into every stylesheet that included it. They are // comments now. Expanded output loses the two comments and nothing else; compressed output is byte-identical.

The manifest suite now fails any documented example whose CSS contains a /* comment. Before the change it failed on reset-css alone.